### PR TITLE
Remove an item intro when there's to many downvotes

### DIFF
--- a/WanderLost/WanderLost/Server/Controllers/MerchantHub.cs
+++ b/WanderLost/WanderLost/Server/Controllers/MerchantHub.cs
@@ -139,13 +139,20 @@ namespace WanderLost.Server.Controllers
             var existingVote = activeMerchant.ClientVotes.FirstOrDefault(v => v.ClientId == clientId);
             if(existingVote == null)
             {
-                activeMerchant.ClientVotes.Add(new Vote()
+                if(activeMerchant.ClientVotes.Count(v => v.VoteType == VoteType.Downvote) > 30)
                 {
-                    ActiveMerchant = activeMerchant,
-                    ClientId = clientId,
-                    VoteType = voteType,
-                });
-                activeMerchant.Votes = activeMerchant.ClientVotes.Sum(v => (int)v.VoteType);
+                    _merchantsDbContext.Remove(activeMerchant);
+                }
+                else
+                {
+                    activeMerchant.ClientVotes.Add(new Vote()
+                    {
+                        ActiveMerchant = activeMerchant,
+                        ClientId = clientId,
+                        VoteType = voteType,
+                    });
+                    activeMerchant.Votes = activeMerchant.ClientVotes.Sum(v => (int)v.VoteType);
+                }
 
                 await _merchantsDbContext.SaveChangesAsync();
 


### PR DESCRIPTION
Changed the vote logic to remove an active merchant intro when there is more than 30 downvotes, this way the merchant page don't get spammed by fake intros.