### PR TITLE
Show the specific rapport item being sold

### DIFF
--- a/WanderLost/WanderLost/Client/Components/ActiveMerchantsGrid.razor
+++ b/WanderLost/WanderLost/Client/Components/ActiveMerchantsGrid.razor
@@ -57,7 +57,7 @@
                     var merchant = merchantGroup.ActiveMerchants.First();
                     <td><ZoneDisplay ZoneName="@merchant.Zone" /></td>
                     <td><ItemDisplay Item="@merchant.Card" /></td>
-                    <td><ItemDisplay Item="@(new Item() { Name = merchant.RapportRarity?.ToString() ?? "", Rarity = merchant.RapportRarity ?? Rarity.Rare})" /></td>
+                    <td><ItemDisplay Item="@merchant.Rapport" /></td>
                     <td style="white-space: nowrap;">
                         @merchant.Votes 
                         <button class="btn @GetVoteButtonCss(merchant.Id, VoteType.Upvote)" alt="Upvote" @onclick="@(async m => await Upvote(merchant.Id))" ><span class="oi oi-thumb-up"></span></button> 
@@ -71,7 +71,7 @@
                 <tr>
                     <td><ZoneDisplay ZoneName="@merchant.Zone" /></td>
                     <td><ItemDisplay Item="@merchant.Card" /></td>
-                    <td><ItemDisplay Item="@(new Item() { Name = merchant.RapportRarity?.ToString() ?? "", Rarity = merchant.RapportRarity ?? Rarity.Rare})" /></td>
+                    <td><ItemDisplay Item="@merchant.Rapport" /></td>
                     <td style="white-space: nowrap;">
                         @merchant.Votes
                         <button class="btn @GetVoteButtonCss(merchant.Id, VoteType.Upvote)" alt="Upvote" @onclick="@(async m => await Upvote(merchant.Id))" ><span class="oi oi-thumb-up"></span></button> 

--- a/WanderLost/WanderLost/Client/Pages/Notifications.razor.cs
+++ b/WanderLost/WanderLost/Client/Pages/Notifications.razor.cs
@@ -59,12 +59,13 @@ namespace WanderLost.Client.Pages
                 Name = "Lailai",
                 Zones = new List<string> { "Punika" },
                 Cards = new List<Item> { new Item { Name = "Shut up!!", Rarity = Rarity.Rare } },
+                Rapports = new List<Item> { new Item { Name = "Flower", Rarity = Rarity.Rare } },
             };
             var dummyMerchantGroup = new ActiveMerchantGroup
             {
                 MerchantData = dummyData,
                 MerchantName = "Lailai",
-                ActiveMerchants = new List<ActiveMerchant> { new ActiveMerchant { Name = "Lailai", Card = dummyData.Cards[0], Zone = dummyData.Zones[0], RapportRarity = Rarity.Rare } },
+                ActiveMerchants = new List<ActiveMerchant> { new ActiveMerchant { Name = "Lailai", Card = dummyData.Cards[0], Zone = dummyData.Zones[0], Rapport = dummyData.Rapports[0] } },
             };
             await ClientNotifications.ForceMerchantFoundNotification(dummyMerchantGroup);
         }

--- a/WanderLost/WanderLost/Client/Pages/UpdateMerchant.razor
+++ b/WanderLost/WanderLost/Client/Pages/UpdateMerchant.razor
@@ -48,15 +48,14 @@
             <div class="card border-secondary mb-3">
                 <div class="card-header">Rapport Item</div>
                 <div class="card-body">
-                    <InputRadioGroup @bind-Value="ActiveMerchant.RapportRarity">
-                        <div class="form-check">
-                            <InputRadio class="form-check-input" Value="@Rarity.Epic" id="EpicRapport"/>
-                            <label class="form-check-label" for="EpicRapport"><ItemDisplay Item="@(new Item(){ Name="Epic", Rarity= Rarity.Epic })" /></label>
-                        </div>
-                        <div class="form-check">
-                            <InputRadio class="form-check-input" Value="@Rarity.Legendary" id="LegendaryRapport"/>
-                            <label class="form-check-label" for="LegendaryRapport"><ItemDisplay Item="@(new Item(){ Name="Legendary", Rarity= Rarity.Legendary })" /></label>
-                        </div>
+                    <InputRadioGroup @bind-Value="RapportName">
+                        @foreach(var item in MerchantData?.Rapports ?? Enumerable.Empty<Item>())
+                        {
+                            <div class="form-check">
+                                <InputRadio class="form-check-input" Value="@item.Name" id="@item.Name"/>
+                                <label class="form-check-label" for="@item.Name"><ItemDisplay Item="@item" /></label>
+                            </div>
+                        }
                     </InputRadioGroup>
                 </div>
             </div>
@@ -87,6 +86,19 @@
             if(card is not null)
             {
                 ActiveMerchant.Card = card;
+            }
+        }
+    }
+
+    public string RapportName
+    {
+        get{ return ActiveMerchant.Rapport.Name; }
+        set 
+        {
+            var rapport = MerchantData?.Rapports?.FirstOrDefault(c => value == c.Name);
+            if(rapport is not null)
+            {
+                ActiveMerchant.Rapport = rapport;
             }
         }
     }

--- a/WanderLost/WanderLost/Client/Services/ClientNotificationService.cs
+++ b/WanderLost/WanderLost/Client/Services/ClientNotificationService.cs
@@ -74,7 +74,7 @@ namespace WanderLost.Client.Services
                 }
             }
 
-            if (_clientSettings.NotifyLegendaryRapport && merchantGroup.ActiveMerchants.Any(m => m.RapportRarity == Rarity.Legendary))
+            if (_clientSettings.NotifyLegendaryRapport && merchantGroup.ActiveMerchants.Any(m => m.Rapport.Rarity == Rarity.Legendary))
             {
                 return true;
             }
@@ -112,7 +112,7 @@ namespace WanderLost.Client.Services
             {
                 body += $"Location: {merchantGroup.ActiveMerchants[0].Zone}\n";
                 body += $"Card: {merchantGroup.ActiveMerchants[0].Card.Name}\n";
-                body += $"Rapport: {merchantGroup.ActiveMerchants[0].RapportRarity?.ToString() ?? "_unknown"}\n";
+                body += $"Rapport: {merchantGroup.ActiveMerchants[0].Rapport.Name}\n";
             }
 
             return _notifications.CreateAsync($"Wandering Merchant \"{merchantGroup.MerchantName}\" found", new NotificationOptions { Body = body, Renotify = true, Tag = $"found_{merchantGroup.MerchantName}", Icon = "images/notifications/ExclamationMark.png" });

--- a/WanderLost/WanderLost/Client/wwwroot/data/merchants.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/merchants.json
@@ -18,6 +18,24 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Book of Survival",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Broken Dagger",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Desiccated Wooden Statue",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Red Moon Tears",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Morris": {
     "Name": "Morris",
@@ -42,6 +60,24 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Azenaporium Brooch",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Dyorika Straw Hat",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Model of Luterra's Sword",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Chain War Chronicles",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Lucas": {
     "Name": "Lucas",
@@ -62,6 +98,20 @@
         "Rarity": "Rare"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Yudia Natural Salt",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Yudia Spellbook",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Sky Reflection Oil",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Mac": {
     "Name": "Mac",
@@ -86,6 +136,16 @@
         "Rarity": "Legendary"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Tournament Entrance Stamp",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Angler's Fishing Pole",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Jeffrey": {
     "Name": "Jeffrey",
@@ -106,8 +166,17 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Shimmering Essence",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Sirius's Holy Book",
+        "Rarity": "Legendary"
+      }
+    ]
   },
-
   "Ben": {
     "Name": "Ben",
     "Region": "Rethramis",
@@ -127,6 +196,24 @@
         "Rarity": "Rare"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Fancier Bouquet",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Prideholme Potato",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Rethramis Holy Water",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Surprise Chest",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Laitir": {
     "Name": "Laitir",
@@ -147,6 +234,16 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Piyer's Secret Textbook",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Fargar's Beer",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Peter": {
     "Name": "Peter",
@@ -167,8 +264,33 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Crystallized Magick",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Exquisite Music Box",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Goblin Yam",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Magick Cloth",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Queen's Knights Application",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Vern's Founding Coin",
+        "Rarity": "Legendary"
+      }
+    ]
   },
-
   "Malone": {
     "Name": "Malone",
     "Region": "West Luterra",
@@ -188,6 +310,24 @@
         "Rarity": "Rare"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Black Rose",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Lakebar Tomato Juice",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Stalwart Cage",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Chain War Chronicles",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Burt": {
     "Name": "Burt",
@@ -208,6 +348,24 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Azenaporium Brooch",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Dyorika Straw Hat",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Model of Luterra's Sword",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Chain War Chronicles",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Oliver": {
     "Name": "Oliver",
@@ -228,6 +386,24 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Mokoko Carrot",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Oversized Ladybug Doll",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Round Glass Piece",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Shy Wind Flower Pollen",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Nox": {
     "Name": "Nox",
@@ -248,6 +424,16 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Energy X7 Capsule",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Fine Gramophone",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Aricer": {
     "Name": "Aricer",
@@ -268,6 +454,24 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Danube's Earrings",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Elemental's Feather",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Soundstone of Dawn",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Sylvain Queens' Blessing",
+        "Rarity": "Legendary"
+      }
+    ]
   },
   "Rayni": {
     "Name": "Rayni",
@@ -292,5 +496,23 @@
         "Rarity": "Epic"
       }
     ],
+    "Rapports": [
+      {
+        "Name": "Hollowfruit",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Pinata Crafting Set",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Rainbow Tikatika Flower",
+        "Rarity": "Epic"
+      },
+      {
+        "Name": "Oreha Viewing Stone",
+        "Rarity": "Legendary"
+      }
+    ]
   }
 }

--- a/WanderLost/WanderLost/Client/wwwroot/data/merchants.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/merchants.json
@@ -378,7 +378,7 @@
         "Rarity": "Uncommon"
       },
       {
-        "Name": "Eohl",
+        "Name": "Eolh",
         "Rarity": "Rare"
       },
       {

--- a/WanderLost/WanderLost/Server/Controllers/MerchantHub.cs
+++ b/WanderLost/WanderLost/Server/Controllers/MerchantHub.cs
@@ -98,7 +98,7 @@ namespace WanderLost.Server.Controllers
             {
                 Card = merchant.Card,
                 Name = merchant.Name,
-                RapportRarity = merchant.RapportRarity,
+                Rapport = merchant.Rapport,
                 UploadedBy = clientId,
                 Zone = merchant.Zone,
                 Hidden = true,
@@ -268,7 +268,7 @@ namespace WanderLost.Server.Controllers
                 _merchantsDbContext.Attach(merchant);
                 await _merchantsDbContext.SaveChangesAsync();
             }
-            else if (merchant.Votes < -5 && merchant.RapportRarity == Rarity.Legendary)
+            else if (merchant.Votes < -5 && merchant.Rapport.Rarity == Rarity.Legendary)
             {
                 merchant.Hidden = true;
 

--- a/WanderLost/WanderLost/Server/Migrations/20220421002727_RapportItems.Designer.cs
+++ b/WanderLost/WanderLost/Server/Migrations/20220421002727_RapportItems.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WanderLost.Server.Controllers;
 
@@ -11,9 +12,10 @@ using WanderLost.Server.Controllers;
 namespace WanderLost.Server.Migrations
 {
     [DbContext(typeof(MerchantsDbContext))]
-    partial class MerchantsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220421002727_RapportItems")]
+    partial class RapportItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WanderLost/WanderLost/Server/Migrations/20220421002727_RapportItems.cs
+++ b/WanderLost/WanderLost/Server/Migrations/20220421002727_RapportItems.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WanderLost.Server.Migrations
+{
+    public partial class RapportItems : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RapportRarity",
+                table: "ActiveMerchants");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Rapport_Name",
+                table: "ActiveMerchants",
+                type: "nvarchar(40)",
+                maxLength: 40,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Rapport_Rarity",
+                table: "ActiveMerchants",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Rapport_Name",
+                table: "ActiveMerchants");
+
+            migrationBuilder.DropColumn(
+                name: "Rapport_Rarity",
+                table: "ActiveMerchants");
+
+            migrationBuilder.AddColumn<int>(
+                name: "RapportRarity",
+                table: "ActiveMerchants",
+                type: "int",
+                nullable: true);
+        }
+    }
+}

--- a/WanderLost/WanderLost/Shared/Data/ActiveMerchant.cs
+++ b/WanderLost/WanderLost/Shared/Data/ActiveMerchant.cs
@@ -18,7 +18,7 @@ namespace WanderLost.Shared.Data
 
         public Item Card { get; set; } = new();
 
-        public Rarity? RapportRarity { get; set; }
+        public Item Rapport { get; set; } = new();
 
         public int Votes { get; set; }
 
@@ -39,7 +39,7 @@ namespace WanderLost.Shared.Data
         {
             Zone = string.Empty;
             Card = new();
-            RapportRarity = null;
+            Rapport = new();
         }
 
         public void CopyInstance(ActiveMerchant other)
@@ -47,33 +47,30 @@ namespace WanderLost.Shared.Data
             //Copies only data sent between client and server
             Zone = other.Zone;
             Card = other.Card;
-            RapportRarity = other.RapportRarity;
+            Rapport = other.Rapport;
         }
 
         public bool IsValid(Dictionary<string, MerchantData> allMerchantData)
         {
             if (string.IsNullOrWhiteSpace(Name) ||
-                string.IsNullOrWhiteSpace(Zone) ||
-                RapportRarity is null)
+                string.IsNullOrWhiteSpace(Zone))
             {
                 return false;
             }
 
-            if (!allMerchantData.ContainsKey(Name)) return false;
-
-            var data = allMerchantData[Name];
+            if (!allMerchantData.TryGetValue(Name, out var data)) return false;
 
             return data.Zones.Contains(Zone) &&
-                    data.Cards.Any(c => c.Name == Card.Name && c.Rarity == Card.Rarity);
+                    data.Cards.Contains(Card) &&
+                    data.Rapports.Contains(Rapport);
         }
 
         public bool IsEqualTo(ActiveMerchant merchant)
         {
             return Name == merchant.Name &&
                 Zone == merchant.Zone &&
-                Card.Name == merchant.Card.Name &&
-                Card.Rarity == merchant.Card.Rarity &&
-                RapportRarity == merchant.RapportRarity;
+                Card.Equals(merchant.Card) &&
+                Rapport.Equals(merchant.Rapport);
         }
     }
 }

--- a/WanderLost/WanderLost/Shared/Data/Item.cs
+++ b/WanderLost/WanderLost/Shared/Data/Item.cs
@@ -4,10 +4,17 @@ using System.ComponentModel.DataAnnotations;
 namespace WanderLost.Shared.Data
 {
     [Owned]
-    public class Item
+    public class Item : IEquatable<Item>
     {
         [MaxLength(40)]
         public string Name { get; init; } = string.Empty;
         public Rarity Rarity { get; init; }
+
+        public bool Equals(Item? other)
+        {
+            return other is not null &&
+                Name == other.Name && 
+                Rarity == other.Rarity;
+        }
     }
 }

--- a/WanderLost/WanderLost/Shared/Data/MerchantData.cs
+++ b/WanderLost/WanderLost/Shared/Data/MerchantData.cs
@@ -7,5 +7,6 @@
         public List<TimeSpan> AppearanceTimes { get; init; } = new();
         public List<string> Zones { get; init; } = new();
         public List<Item> Cards { get; init; } = new();
+        public List<Item> Rapports { get; init; } = new();
     }
 }

--- a/WanderLost/WanderLost/Shared/Utils.cs
+++ b/WanderLost/WanderLost/Shared/Utils.cs
@@ -41,6 +41,11 @@ namespace WanderLost.Shared
                     new Item() { Name = "Jack O'Neill", Rarity = Rarity.Relic },
                     new Item() { Name = "Jaffa", Rarity = Rarity.Normal },
                 },
+                Rapports =
+                {
+                    new Item() { Name = "Lightsaber", Rarity = Rarity.Legendary },
+                    new Item() { Name = "Half-Eaten Cookie", Rarity = Rarity.Normal },
+                },
                 AppearanceTimes = times,
             });
         }


### PR DESCRIPTION
...instead of just epic/legendary

![image](https://user-images.githubusercontent.com/55425826/164349654-7336aec5-e62b-42c4-815c-79984a3219ab.png)
![image](https://user-images.githubusercontent.com/55425826/164349663-67fc81a5-5ac2-4bd2-bf0c-3bc5608a914e.png)

Closes #36

I haven't used this EF migration stuff before so do check that. It's probably OK to nuke the old RapportRarity column since we don't really need to keep that data for more than an hour.

