### PR TITLE
Notification thresholds

### DIFF
--- a/WanderLost/WanderLost/Client/MerchantNotificationSetting.cs
+++ b/WanderLost/WanderLost/Client/MerchantNotificationSetting.cs
@@ -1,6 +1,4 @@
-﻿using WanderLost.Shared.Data;
-
-namespace WanderLost.Client
+﻿namespace WanderLost.Client
 {
     public class MerchantNotificationSetting
     {

--- a/WanderLost/WanderLost/Client/MerchantNotificationSetting.cs
+++ b/WanderLost/WanderLost/Client/MerchantNotificationSetting.cs
@@ -1,4 +1,6 @@
-﻿namespace WanderLost.Client
+﻿using WanderLost.Shared.Data;
+
+namespace WanderLost.Client
 {
     public class MerchantNotificationSetting
     {

--- a/WanderLost/WanderLost/Client/Pages/Merchants.razor.cs
+++ b/WanderLost/WanderLost/Client/Pages/Merchants.razor.cs
@@ -92,6 +92,10 @@ namespace WanderLost.Client.Pages
                 {
                     merchant.Votes = voteTotal;
                 }
+                if (ActiveData.MerchantGroups.FirstOrDefault(mg => mg.ActiveMerchants.Any(m => m.Id == merchantId)) is ActiveMerchantGroup merchantGroup)
+                {
+                    await Notifications.RequestMerchantFoundNotification(merchantGroup);
+                }
 
                 await InvokeAsync(StateHasChanged);
             }));

--- a/WanderLost/WanderLost/Client/Pages/Notifications.razor
+++ b/WanderLost/WanderLost/Client/Pages/Notifications.razor
@@ -23,7 +23,9 @@ else
                     Notify when selected items appear
                 </label>
             </div>
-            <button class="btn btn-dark col-auto" @onclick="OnTestMerchantSpawnClicked">Test merchant spawn notification</button>
+            <div class="col-auto">
+                <button class="btn btn-dark" @onclick="OnTestMerchantSpawnClicked">Test merchant spawn notification</button>
+            </div>
         </div>
         <div class="row my-2">
             <div class="form-check col-6">
@@ -32,7 +34,25 @@ else
                     Play additional notification sound in browser
                 </label>
             </div>
-            <button class="btn btn-dark col-auto" @onclick="OnTestMerchantFoundClicked">Test item found notification</button>
+            <div class="col-auto">
+                <button class="btn btn-dark" @onclick="OnTestMerchantFoundClicked">Test item found notification</button>
+            </div>
+        </div>
+        <div class="row my-2">
+            <div class="col-6">
+                <span class="form-control-plaintext">Minimum upvotes for notification on <ItemDisplay Item="@(new Item { Name = "legendary Card", Rarity = Rarity.Legendary })" /> </span>
+            </div>
+            <div class="col-auto">
+                <input type="number" class="form-control" @bind="CardVoteThresholdWrapper" />
+            </div>
+        </div>
+        <div class="row my-2">
+            <div class="col-6">
+                <span class="form-control-plaintext">Minimum upvotes for notification on <ItemDisplay Item="@(new Item { Name = "legendary Rapport", Rarity = Rarity.Legendary })" /> </span>
+            </div>
+            <div class="col-auto">
+                <input type="number" class="form-control" @bind="RapportVoteThresholdWrapper" />
+            </div>
         </div>
     </div>
     <div class="d-flex overflow-hidden flex-wrap">

--- a/WanderLost/WanderLost/Client/Pages/Notifications.razor.cs
+++ b/WanderLost/WanderLost/Client/Pages/Notifications.razor.cs
@@ -16,6 +16,8 @@ namespace WanderLost.Client.Pages
             await StaticData.Init();
             await ClientSettings.Init();
 
+            _cardVoteThresholdWrapper = ClientSettings.CardVoteThresholdForNotification.GetValueOrDefault(Rarity.Legendary);
+            _rapportVoteThresholdWrapper = ClientSettings.RapportVoteThresholdForNotification.GetValueOrDefault(Rarity.Legendary);
             await base.OnInitializedAsync();
         }
 
@@ -125,5 +127,44 @@ namespace WanderLost.Client.Pages
 
             return false;
         }
+
+        private async void SetCardVoteThreshold(Rarity rarity, int newThreshold)
+        {
+            ClientSettings.CardVoteThresholdForNotification[rarity] = newThreshold;
+            await ClientSettings.SaveCardVoteThresholdForNotification();
+        }
+
+        private async void SetRapportVoteThreshold(Rarity rarity, int newThreshold)
+        {
+            ClientSettings.RapportVoteThresholdForNotification[rarity] = newThreshold;
+            await ClientSettings.SaveRapportVoteThresholdForNotification();
+        }
+
+        private int _cardVoteThresholdWrapper;
+
+        public int CardVoteThresholdWrapper
+        {
+            get { return _cardVoteThresholdWrapper; }
+            set 
+            {
+                if (value < 0) value = 0;
+                _cardVoteThresholdWrapper = value;
+                SetCardVoteThreshold(Rarity.Legendary, value);
+            }
+        }
+
+        private int _rapportVoteThresholdWrapper;
+
+        public int RapportVoteThresholdWrapper
+        {
+            get { return _rapportVoteThresholdWrapper; }
+            set
+            {
+                if (value < 0) value = 0;
+                _rapportVoteThresholdWrapper = value;
+                SetRapportVoteThreshold(Rarity.Legendary, value);
+            }
+        }
+
     }
 }

--- a/WanderLost/WanderLost/Client/Services/ClientSettingsController.cs
+++ b/WanderLost/WanderLost/Client/Services/ClientSettingsController.cs
@@ -10,6 +10,8 @@ namespace WanderLost.Client.Services
         public bool NotificationsEnabled { get; private set; }
         public bool NotifyBrowserSoundEnabled { get; private set; }
         public Dictionary<string, MerchantNotificationSetting> Notifications { get; private set; } = new();
+        public Dictionary<Rarity, int> CardVoteThresholdForNotification { get; set; } = new();
+        public Dictionary<Rarity, int> RapportVoteThresholdForNotification { get; set; } = new();
 
         private bool _initialized = false;
 
@@ -33,9 +35,11 @@ namespace WanderLost.Client.Services
                 NotificationsEnabled = await _localStorageService.GetItemAsync<bool?>(nameof(NotificationsEnabled)) ?? false;
                 NotifyBrowserSoundEnabled = await _localStorageService.GetItemAsync<bool?>(nameof(NotifyBrowserSoundEnabled)) ?? false;
                 Notifications = await _localStorageService.GetItemAsync<Dictionary<string, MerchantNotificationSetting>?>(nameof(Notifications)) ?? new();
+                CardVoteThresholdForNotification = await _localStorageService.GetItemAsync<Dictionary<Rarity, int>?>(nameof(CardVoteThresholdForNotification)) ?? new();
+                RapportVoteThresholdForNotification = await _localStorageService.GetItemAsync<Dictionary<Rarity, int>?>(nameof(RapportVoteThresholdForNotification)) ?? new();
 
                 //Compatability to convert/remove old settings to items
-                if(await _localStorageService.GetItemAsync<bool?>("NotifyLegendaryRapport") ?? false)
+                if (await _localStorageService.GetItemAsync<bool?>("NotifyLegendaryRapport") ?? false)
                 {
                     foreach(var merchant in _staticData.Merchants.Values)
                     {
@@ -85,6 +89,16 @@ namespace WanderLost.Client.Services
         public async Task SaveNotificationSettings()
         {
             await _localStorageService.SetItemAsync(nameof(Notifications), Notifications);
+        }
+
+        public async Task SaveCardVoteThresholdForNotification()
+        {
+            await _localStorageService.SetItemAsync(nameof(CardVoteThresholdForNotification), CardVoteThresholdForNotification);
+        }
+
+        public async Task SaveRapportVoteThresholdForNotification()
+        {
+            await _localStorageService.SetItemAsync(nameof(RapportVoteThresholdForNotification), RapportVoteThresholdForNotification);
         }
     }
 }


### PR DESCRIPTION
You once suggested upvote thresholds for notifications on legendary items (also #64 ). This PR will allow users to set custom thresholds for legendary cards and rapports respectively. The values can be set in the Notifications page.

I added threshold values in ClientSettingsController for both cards and rapports for each rarity, although currently only the legendary rarity is being used. But maybe we want to extend this in the future (see notification settings, stuff grows big fast), so it's already prepared for this case. 
Additionally a notification is now requested on every OnUpdateVoteTotal hub-message. To prevent the resulting notification spam on each upvote, I added an internal "cooldown" timer in ClientNotificationService so each merchant can only have one notification per spawn cycle.

One last thing I did not implement yet but could be important: A popup for users to inform them of the new feature, so they set their thresholds. I'm picturing something like the browser-sound-disabled popup from #33 , just different placement and color. Let me know what you think.