### PR TITLE
Add new merged server names

### DIFF
--- a/WanderLost/WanderLost/Client/wwwroot/data/servers.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/servers.json
@@ -38,11 +38,13 @@
     "UtcOffset": "01:00:00",
     "Servers": [
       "Antares",
+      "Armen",
       "Asta",
-      "Balthorr",
       "Beatrice",
       "Brelshaza",
       "Calvasus",
+      "Evergrace",
+      "Ezrebet",
       "Inanna",
       "Kadan",
       "Lazenith",
@@ -53,11 +55,9 @@
       "Sceptrum",
       "Sirius",
       "Slen",
-      "Starlight",
       "Thaemine",
       "Thirain",
       "Trixion",
-      "Twilightmist",
       "Wei",
       "Zinnervale"
     ]

--- a/WanderLost/WanderLost/Client/wwwroot/data/servers.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/servers.json
@@ -39,11 +39,13 @@
     "Servers": [
       "Antares",
       "Asta",
+      "Balthorr",
       "Beatrice",
       "Brelshaza",
       "Calvasus",
       "Inanna",
       "Kadan",
+      "Lazenith",
       "Mokoko",
       "Neria",
       "Nineveh",
@@ -51,9 +53,11 @@
       "Sceptrum",
       "Sirius",
       "Slen",
+      "Starlight",
       "Thaemine",
       "Thirain",
       "Trixion",
+      "Twilightmist",
       "Wei",
       "Zinnervale"
     ]


### PR DESCRIPTION
As per https://www.playlostark.com/en-us/news/articles/server_merge,

On September 28th some servers will be merged and on EUC they've decided to create newly named entries for the resulting merged servers:
```
Sirius will merge with Sceptrum and become Starlight
Thaemine will merge with Procyon and become Lazenith
Nineveh will merge with Beatrice and become Twilightmist
Brelshaza will merge with Inanna and become Balthorr
```

Currently adding those new names alongside with the to be merged servers so there's no need to couple this WanderLost update with the actual server merge.