### PR TITLE
Move timezone for EU servers

### DIFF
--- a/WanderLost/WanderLost/Client/wwwroot/data/servers.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/servers.json
@@ -37,7 +37,7 @@
   },
   "EUC": {
     "Name": "EU Central",
-    "TimeZone": "Europe/Warsaw",
+    "TimeZone": "Europe/Sofia",
     "Servers": [
       "Antares",
       "Armen",


### PR DESCRIPTION
As we have known for a while, Lost Ark does not respect DST. Or at least it doesn't work the way people would expect. Now after the autumn time change, our clocks moved (including the ones for Europe/Warsaw, Europe/Sofia, and all others respecting DST) and now Europe/Warsaw (UTC+1 currently) is 1 hour behind server time, while Europe/Sofia (UTC+2 currently) is aligned with server time.

A permanent change (maybe?) would be to just hardcode UTC+2 or use a timezone that uses UTC+2 and doesn't respect DST. But we never know what Lost Ark would do with their server times, so that also might not prove useful. We might just end up being slaves to this issue.