### PR TITLE
Revert "Update EU to non-DST time zone"

### DIFF
--- a/WanderLost/WanderLost/Client/wwwroot/data/servers.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/servers.json
@@ -37,7 +37,7 @@
   },
   "EUC": {
     "Name": "EU Central",
-    "TimeZone": "Africa/Johannesburg",
+    "TimeZone": "Europe/Warsaw",
     "Servers": [
       "Antares",
       "Armen",


### PR DESCRIPTION
This reverts commit f8856c2fb437277737c9822aff561da1fc7f0798.

Oh well.. My apologies for causing trouble, perhaps we should've indeed waited more.
As mentioned [here](https://github.com/Xeio/WanderLost/pull/223#issuecomment-1799419624), AGS actually decided to adapt the time for EU as well (people had complained). And I can confirm that merchants spawned at 17:00 GMT+2, or 16:00 GMT+1 which is Warsaw's time. And expiration is correct in-game as well. Thus we need to revert the last change and it seems like DST will be the way to go (in Warsaw's timezone as well), as long as AGS makes a habit of this and keeps adapting the time in-game.

Feel free to close this PR and make the change yourself if you'd like. 