### PR TITLE
Add Solas to Burt

### DIFF
--- a/WanderLost/WanderLost/Client/wwwroot/data/merchants.json
+++ b/WanderLost/WanderLost/Client/wwwroot/data/merchants.json
@@ -349,6 +349,10 @@
     "SpawnTimes": [ 4, 10, 4, 10, 10, 10, 4 ],
     "Cards": [
       {
+        "Name": "Executor Solas",
+        "Rarity": "Uncommon"
+      },
+      {
         "Name": "Nox",
         "Rarity": "Rare"
       },


### PR DESCRIPTION
feat: add solas to burt merchant

According to [Lost Ark Codex](https://lostarkcodex.com/us/item/63200195/), Burt has it now